### PR TITLE
uv download: pad progress bar right margin, add CLI example

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1159,7 +1159,11 @@ pub enum ProjectCommand {
     /// virtual workspace roots are silently omitted; other workspace members,
     /// local path, editable, and git dependencies are skipped with a warning.
     #[command(
-        after_help = "Use `uv help download` for more details.",
+        after_help = "\
+Example:
+  $ uv download --platform linux --machine aarch64 -o pkgs --default-index https://mirrors.ustc.edu.cn/pypi/simple/ -p 3.10
+
+Use `uv help download` for more details.",
         after_long_help = ""
     )]
     Download(Box<DownloadArgs>),

--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -776,7 +776,7 @@ impl DownloadProjectReporter {
             // so narrow terminals (<60 col) don't re-wrap the bar onto a third line.
             progress.set_style(
                 ProgressStyle::with_template(
-                    "{wide_msg:.cyan}\n  {wide_bar:.green/dim} {binary_bytes:>10}/{binary_total_bytes:10}",
+                    "{wide_msg:.cyan}\n  {wide_bar:.green/dim} {binary_bytes:>10}/{binary_total_bytes:10}  ",
                 )
                 .unwrap()
                 .progress_chars("--"),


### PR DESCRIPTION
- reporters.rs: append 2 trailing spaces to the per-file download template so the byte counter doesn't sit flush against the terminal edge. {wide_bar} auto-shrinks by 2 chars, matching the existing 2-space left indent for visual symmetry.
- lib.rs: add a usage example to the Download `after_help`, with flags ordered to match the `uv download --help` rendering order.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
